### PR TITLE
Refactor the gulpfile script.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -6,6 +6,6 @@
     </head>
     <body>
         <h1>Example page of the floorplan application.</h1>
-        <script src="../dist/bundle.js"></script>
+        <script src="../dist/main.bundle.js"></script>
     </body>
 </html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ gulp.task('default', () => {
         bundler = watchify(bundler);
 
         const filename = app.replace(/^.*[\\\/]/, '');
-        watchfn = getBundlerHandler(bundler, filename);
+        const watchfn = getBundlerHandler(bundler, filename);
         bundler.on('update', watchfn);
         bundler.on('log', gutil.log);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var gulp        = require('gulp'),
     browserify  = require('browserify'),
     vinyl       = require('vinyl-source-stream'),

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "devDependencies": {
     "@types/jasmine": "^2.5.47",
     "browserify": "^14.3.0",
+    "event-stream": "^3.3.4",
     "gulp": "^3.9.1",
+    "gulp-rename": "^1.2.2",
     "gulp-typescript": "^3.1.6",
     "gulp-util": "^3.0.8",
     "jasmine": "^2.5.3",


### PR DESCRIPTION
This refactor allow us to create multiple entry points while keeping our
automatic recompile on changes.

For example, let say we have those entry points :
* main entry point of our application: `main.ts`
* examples entry point, where we display some UI examples: `examples.ts`

With the old gulp file, the watch mode was coupled with the browserify build routine. With this refactor, we can define a list of entry points and browserify will build a bundle file for each entry point WHILE keeping the watch functionnality untouched.


