### PR TITLE
Remove port binding command from the docker_run_cmd variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-docker_run_cmd = docker run --rm -t -i -p 3000:3000 -v $$(pwd):/opt/floorplan -w /opt/floorplan -u $$(id -u):$$(id -g)
+docker_run_cmd = docker run --rm -t -i -v $$(pwd):/opt/floorplan -w /opt/floorplan -u $$(id -u):$$(id -g)
 
 all:
-	$(docker_run_cmd) node npm start
+	$(docker_run_cmd) -p 3000:3000 node npm start
 
 node_modules:
 	$(docker_run_cmd) node npm install


### PR DESCRIPTION
## based on #9 

Only the npm start script needs to bind container's port 3000 to host's port 3000.
This was causing an error when running the development server and running the test at the same time because both container tried to bind port 3000 at the same time.
