### PR TITLE
docker/node: use node:7

### DIFF
--- a/docker/node
+++ b/docker/node
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:7
 
 ARG userid
 


### PR DESCRIPTION
Its better to lock the image to something so we have reproducible builds